### PR TITLE
feat: add support for value comparisons

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,6 +18,13 @@ class DoubleType extends Number {
 class Double extends mongoose.SchemaType {
   constructor(key, options) {
     super(key, options, 'Double');
+
+    Object.assign(this.$conditionalHandlers, {
+      '$lt': val => this.castForQuery(val),
+      '$lte': val => this.castForQuery(val),
+      '$gt': val => this.castForQuery(val),
+      '$gte': val => this.castForQuery(val),
+    });
   }
 
   cast(val) {

--- a/test/index.js
+++ b/test/index.js
@@ -78,4 +78,49 @@ describe('Double', function() {
       assert.equal(doc.double.valueOf(), 1.11);
     });
   });
+
+  describe('comparisons', function() {
+    let ComparisonModel;
+
+    before(function() {
+      return co(function*() {
+        const schema = new mongoose.Schema({ val: Double });
+        ComparisonModel = mongoose.model('ComparisonTest', schema);
+        const doc = new ComparisonModel({ val: 5.01 });
+        yield doc.save();
+      });
+    });
+
+    it('$gt', function() {
+      return co(function*() {
+        assert.ok(yield ComparisonModel.findOne({ val: { $gt: 5 }}));
+        assert.ok(yield ComparisonModel.findOne({ val: { $gt: 5.0 }}));
+        assert.strictEqual(yield ComparisonModel.findOne({ val: { $gt: 5.01 }}), null);
+      });
+    });
+
+    it('$gte', function() {
+      return co(function*() {
+        assert.ok(yield ComparisonModel.findOne({ val: { $gte: 5 }}));
+        assert.ok(yield ComparisonModel.findOne({ val: { $gte: 5.0 }}));
+        assert.strictEqual(yield ComparisonModel.findOne({ val: { $gte: 5.02 }}), null);
+      });
+    });
+
+    it('$lt', function() {
+      return co(function*() {
+        assert.ok(yield ComparisonModel.findOne({ val: { $lt: 6 }}));
+        assert.ok(yield ComparisonModel.findOne({ val: { $lt: 5.02 }}));
+        assert.strictEqual(yield ComparisonModel.findOne({ val: { $lt: 5.01 }}), null);
+      });
+    });
+
+    it('$lte', function() {
+      return co(function*() {
+        assert.ok(yield ComparisonModel.findOne({ val: { $lte: 6 }}));
+        assert.ok(yield ComparisonModel.findOne({ val: { $lte: 5.01 }}));
+        assert.strictEqual(yield ComparisonModel.findOne({ val: { $lte: 5.0 }}), null);
+      });
+    });
+  });
 });


### PR DESCRIPTION
Closes https://github.com/mongoosejs/mongoose-double/issues/8

This PR adds support for `$lt`, `$lte`, `$gt`, and `$gte`. It does this by adding new `$conditionalHandlers` to the instance and delegating to the `handleSingle` and `handleArray`.

Tried this locally and it worked as expected. Test are included.